### PR TITLE
#6 - Handle JSONDecodeError in routing

### DIFF
--- a/src/tiktokapipy/api.py
+++ b/src/tiktokapipy/api.py
@@ -288,7 +288,12 @@ class TikTokAPI:
             except playwright.sync_api.Error:
                 return
 
-            _data = response.json()
+            try:
+                _data = response.json()
+            except json.JSONDecodeError:
+                route.fulfill(response=response)
+                return
+
             extras_json.append(_data)
             api_response = APIResponse.parse_obj(_data)
             api_extras.append(api_response)

--- a/src/tiktokapipy/async_api.py
+++ b/src/tiktokapipy/async_api.py
@@ -4,6 +4,7 @@ Asynchronous API for data scraping
 
 from __future__ import annotations
 
+import json
 import traceback
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Callable, Generic, List, Tuple, Type
@@ -143,7 +144,12 @@ class AsyncTikTokAPI(TikTokAPI):
             except playwright.async_api.Error:
                 return
 
-            _data = await response.json()
+            try:
+                _data = await response.json()
+            except json.JSONDecodeError:
+                await route.fulfill(response=response)
+                return
+
             extras_json.append(_data)
             api_response = APIResponse.parse_obj(_data)
             api_extras.append(api_response)


### PR DESCRIPTION
* Bug from updating to use features implemented in Playwright v1.29 (2fc7974ad882b5f47e3928e4a71b82aaa28d104b):
  * `Response.json()` throws a JSONDecodeError on an unparseable body
  * Catch and fulfill without continuing