### PR TITLE
Change type of SubtitleData.format field to str

### DIFF
--- a/src/tiktokapipy/models/video.py
+++ b/src/tiktokapipy/models/video.py
@@ -41,7 +41,7 @@ class SubtitleData(TitleCaseModel):
     url: str = Field(alias="Url")
     url_expire: int = Field(alias="UrlExpire")
     format: str = Field(alias="Format")
-    version: int = Field(alias="Version")
+    version: str = Field(alias="Version")
     source: str = Field(alias="Source")
     size: int = Field(alias="Size")
 


### PR DESCRIPTION
SubtitleData.format field can also be a string. Here is one such example:
```
video-embed-bot_1  | 2024-07-04 22:04:07,035 ERROR Failed downloading https://vm.tiktok.com/ZGesWbcYj/: 1 validation error for VideoPage
video-embed-bot_1  | itemInfo.itemStruct.video.subtitleInfos.0.Version
video-embed-bot_1  |   Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='1:whisper_lid', input_type=str]
video-embed-bot_1  |     For further information visit https://errors.pydantic.dev/2.7/v/int_parsing
video-embed-bot_1  | 2024-07-04 22:04:07,534 ERROR Ignoring exception in on_message
video-embed-bot_1  | Traceback (most recent call last):
video-embed-bot_1  |   File "/root/.local/share/virtualenvs/app-4PlAip0Q/lib/python3.12/site-packages/discord/client.py", line 449, in _run_event
video-embed-bot_1  |     await coro(*args, **kwargs)
video-embed-bot_1  |   File "/app/bots/discord/client.py", line 73, in on_message
video-embed-bot_1  |     raise e
video-embed-bot_1  |   File "/app/bots/discord/client.py", line 66, in on_message
video-embed-bot_1  |     post = await client.get_post()
video-embed-bot_1  |            ^^^^^^^^^^^^^^^^^^^^^^^
video-embed-bot_1  |   File "/app/downloader/tiktok.py", line 31, in get_post
video-embed-bot_1  |     video = await api.video(clean_url)
video-embed-bot_1  |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
video-embed-bot_1  |   File "/root/.local/share/virtualenvs/app-4PlAip0Q/lib/python3.12/site-packages/tiktokapipy/async_api.py", line 191, in video
video-embed-bot_1  |     response = VideoPage.model_validate(
video-embed-bot_1  |                ^^^^^^^^^^^^^^^^^^^^^^^^^
video-embed-bot_1  |   File "/root/.local/share/virtualenvs/app-4PlAip0Q/lib/python3.12/site-packages/pydantic/main.py", line 551, in model_validate
video-embed-bot_1  |     return cls.__pydantic_validator__.validate_python(
video-embed-bot_1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
video-embed-bot_1  | pydantic_core._pydantic_core.ValidationError: 1 validation error for VideoPage
video-embed-bot_1  | itemInfo.itemStruct.video.subtitleInfos.0.Version
video-embed-bot_1  |   Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='1:whisper_lid', input_type=str]
```

Tested by monkey-patching the lib.