### PR TITLE
accept string types for SubtitleData

### DIFF
--- a/src/tiktokapipy/models/video.py
+++ b/src/tiktokapipy/models/video.py
@@ -41,7 +41,7 @@ class SubtitleData(TitleCaseModel):
     url: str = Field(alias="Url")
     url_expire: int = Field(alias="UrlExpire")
     format: str = Field(alias="Format")
-    version: int = Field(alias="Version")
+    version: Union[int, str] = Field(alias="Version")
     source: str = Field(alias="Source")
     size: int = Field(alias="Size")
 


### PR DESCRIPTION
```
class SubtitleData(TitleCaseModel):
    version: int = Field(alias="Version")
```
throws out:

> | 2024-10-20 07:46:31,775 - tiktok_bot - ERROR - Validation error in AsyncTikTokAPI: 1 validation error for VideoPage
> | itemInfo.itemStruct.video.subtitleInfos.0.Version
> |   Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='1:whisper_lid', input_type=str]
> |     For further information visit https://errors.pydantic.dev/2.9/v/int_parsing

## we can add accept both integers and strings in `SubtitleData`
### change the version field line to accept both integers and strings:

```
class SubtitleData(TitleCaseModel):
    language_id: Optional[int] = Field(alias="LanguageID", default=None)
    language_code_name: str = Field(alias="LanguageCodeName")
    url: str = Field(alias="Url")
    url_expire: int = Field(alias="UrlExpire")
    format: str = Field(alias="Format")
    version: Union[int, str] = Field(alias="Version")
    source: str = Field(alias="Source")
    size: int = Field(alias="Size")
```
