### PR TITLE
fix scrapping profile page for user data on __UNIVERSAL_DATA_FOR_REHYDRATION__

### DIFF
--- a/src/tiktokapipy/async_api.py
+++ b/src/tiktokapipy/async_api.py
@@ -110,6 +110,10 @@ class AsyncTikTokAPI(TikTokAPI):
                     data = json.loads(data)['__DEFAULT_SCOPE__']['webapp.user-detail']
 
                 await page.close()
+
+                if data.get('statusCode') == 10221:
+                    raise ValueError("Couldn't find this account")
+
                 extracted = self._extract_and_dump_data(data, data_model)
             except (ValidationError, IndexError) as e:
                 traceback.print_exception(type(e), e, e.__traceback__)

--- a/src/tiktokapipy/models/raw_data.py
+++ b/src/tiktokapipy/models/raw_data.py
@@ -16,7 +16,7 @@ from tiktokapipy.models.video import LightVideo, Video
 class UserModule(CamelCaseModel):
     """:autodoc-skip:"""
 
-    users: Dict[str, User]
+    user: Dict[str, User]
     stats: Dict[str, UserStats]
 
 
@@ -30,7 +30,7 @@ class ChallengeInfo(CamelCaseModel):
 class StatusPage(CamelCaseModel):
     """:autodoc-skip:"""
 
-    status_code: int
+    statusCode: int
 
 
 class ChallengePage(StatusPage):
@@ -79,12 +79,25 @@ class ChallengeResponse(PrimaryResponseType):
 DesktopResponseT = TypeVar("DesktopResponseT")
 
 
+class UserInfo(CamelCaseModel):
+    """:autodoc-skip:"""
+    user: User
+    stats: UserStats
+
+
+class ShareMeta(CamelCaseModel):
+    """:autodoc-skip:"""
+    title: str
+    desc: str
+
+
 class UserResponse(PrimaryResponseType):
     """:autodoc-skip:"""
-
-    item_module: Optional[Dict[int, LightVideo]] = None
-    user_module: Optional[UserModule] = None
-    user_page: StatusPage
+    user_info: UserInfo = Field(alias="userInfo")
+    share_meta: ShareMeta = Field(alias="shareMeta")
+    status_code: int = Field(alias="statusCode")
+    status_msg: str = Field(alias="statusMsg")
+    need_fix: bool = Field(alias="needFix")
 
 
 class VideoResponse(PrimaryResponseType):

--- a/src/tiktokapipy/models/video.py
+++ b/src/tiktokapipy/models/video.py
@@ -41,7 +41,7 @@ class SubtitleData(TitleCaseModel):
     url: str = Field(alias="Url")
     url_expire: int = Field(alias="UrlExpire")
     format: str = Field(alias="Format")
-    version: int = Field(alias="Version")
+    version: int | str = Field(alias="Version")
     source: str = Field(alias="Source")
     size: int = Field(alias="Size")
 


### PR DESCRIPTION
I ran into a problem when I tried to request user data using
```
await api.user()
```
And always got an error
```
  response = await self._scrape_data(
                 ^^^^^^^^^^^^^^^^^^^^^^^^
  raise TikTokAPIError(
tik tok api py.TikTokAPIError: Data scraping unable to complete in 30.0s (retries: 0)
```

In the code of the profile page noticed that the id of the script with user information has changed from `SIGI_STATE` to `__UNIVERSAL_DATA_FOR_REHYDRATION__` with the `__DEFAULT_SCOPE__` property, in which user data is contained in the `webapp.user-detail`

Also fixed `version` property type of `SubtitleData`  like in #90 #86 

So this changes working for me and I can fetch videos data